### PR TITLE
Add MLH banner

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,6 +12,7 @@
     <title>CruzHacks 2019</title>
   </head>
   <body>
+    <a id="mlh-trust-badge" style="display:block;max-width:100px;min-width:60px;position:fixed;right:50px;top:0;width:10%;z-index:10000" href="https://mlh.io/seasons/na-2019/events?utm_source=na-hackathon&utm_medium=TrustBadge&utm_campaign=2019-season&utm_content=white" target="_blank"><img src="https://s3.amazonaws.com/logged-assets/trust-badge/2019/mlh-trust-badge-2019-white.svg" alt="Major League Hacking 2019 Hackathon Season" style="width:100%"></a>
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>


### PR DESCRIPTION
Adds MLH banner in the default white style in the top right corner.

ref: https://mlh.io/brand-guidelines